### PR TITLE
bump hogan version to correct empty strings handling (not truthy any more!)

### DIFF
--- a/example/app.coffee
+++ b/example/app.coffee
@@ -22,6 +22,7 @@ app.get '/', (req,res)->
   res.render "index",
     list: [ {title: "first", data: "custom data"}, {title: "Second"}, {title: "third"} ]
     partials: {temp: 'temp'}
+    emptyString: ''
     lambdas:
       reverseString: (text) ->
         return text.split("").reverse().join("")

--- a/example/spec/example-spec.js
+++ b/example/spec/example-spec.js
@@ -45,4 +45,8 @@ describe("example-page", function() {
     expect(cheer("[rel='test-nested-lambdas']").text().trim()).to.be("DLROW")
   });
 
+  it("should not render a variable with a value of empty string (empty strings should not be truthy)", function() {
+    expect(cheer("div.empty-string-container").length).to.be(0);
+  })
+
 });

--- a/example/views/index.html
+++ b/example/views/index.html
@@ -37,6 +37,10 @@ Hello {{what}}!
 
 {{> temp}}
 
+{{#emptyString}}
+  <div class="empty-string-container">{{emptyString}}</div>
+{{/emptyString}}
+
 {{#yield-footer}}
   <p>I'm a footer, defined in index.html</p>
 {{/yield-footer}}

--- a/package.json
+++ b/package.json
@@ -21,7 +21,7 @@
   "author": "Andrew Volkov <hello@vol4ok.net>",
   "license": "MIT",
   "dependencies": {
-    "hogan.js": ">=2.0.0"
+    "hogan.js": "~3.0.2"
   },
   "devDependencies": {
     "coffee-script": "1.x.x",


### PR DESCRIPTION
Hogan v3.0 or greater correctly handles empty strings (as in they are no longer truthy).

Added test as well.
